### PR TITLE
Add missing key props to FormFieldModal component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-datagrid",
-  "version": "0.2.0-alpha.2.0",
+  "version": "0.2.0-alpha.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-datagrid",
-  "version": "0.2.0-alpha.2.1",
+  "version": "0.2.0-alpha.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-datagrid",
-  "version": "0.2.0-alpha.2.1",
+  "version": "0.2.0-alpha.2.2",
   "description": "React data grid component that complies with redux and redux-form. Also exposes a non form version that can be exposed to just render a data grid.",
   "author": "Yadvaindera Sood <ydsood@gmail.com> (https://github.com/ydsood)",
   "license": "ISC",

--- a/src/components/datagridField/FormFieldModal.jsx
+++ b/src/components/datagridField/FormFieldModal.jsx
@@ -24,7 +24,6 @@ class FormFieldModal extends React.Component<Props> {
   buildFormFieldsModal(fieldName: string, index: number, fields: *) {
     const { columnModel, removeContent } = this.props;
     const chunkedColumnModel = buildVariableSizeFieldSection(columnModel);
-    // chunkConditional(columnModel, 2, column => !!column.singleField);
     const fieldToRender = chunkedColumnModel.map((columns) => {
       const mappedFields = columns.map((item) => {
         let field = <div />;
@@ -38,7 +37,9 @@ class FormFieldModal extends React.Component<Props> {
         for (let i = 0; i < fieldMetaResolver.length; i += 1) {
           const fieldResolver = fieldMetaResolver[i];
 
-          if (typeof fieldResolver === "function") meta = fieldResolver(colModelCopy, fields.get(index), item.dataIndex) || meta;
+          if (typeof fieldResolver === "function") {
+            meta = fieldResolver(colModelCopy, fields.get(index), item.dataIndex) || meta;
+          }
         }
 
         meta = { ...meta, label };
@@ -55,6 +56,7 @@ class FormFieldModal extends React.Component<Props> {
             <Field
               {...columnProps}
               name={`${fieldName}.${item.dataIndex}`}
+              key={item.dataIndex}
               component={DefaultFormField}
               validate={validate}
               width={width}
@@ -67,19 +69,23 @@ class FormFieldModal extends React.Component<Props> {
               {...columnProps}
               meta={columnProps.props}
               name={`${fieldName}.${item.dataIndex}`}
+              key={item.dataIndex}
             />
           );
         }
         return field;
       });
+
+      const rowKey = columns.map((c) => c.dataIndex).join(",");
       return (
-        <Form.Group>
+        <Form.Group key={rowKey}>
           { mappedFields }
         </Form.Group>
       );
     });
+
     return (
-      <Segment color="black">
+      <Segment key={fieldName} color="black">
         <Label as="a" icon="trash" color="red" ribbon="right" index={index} onClick={(event, data) => removeContent(data.index)} />
         {fieldToRender}
       </Segment>

--- a/src/components/datagridField/FormFieldModal.jsx
+++ b/src/components/datagridField/FormFieldModal.jsx
@@ -21,27 +21,40 @@ type Props = {
 }
 
 class FormFieldModal extends React.Component<Props> {
+  // eslint-disable-next-line class-methods-use-this
+  applyFieldResolvers(columnModel, rowData) {
+    return columnModel.map((column) => {
+      const colModelCopy = _.cloneDeep(columnModel);
+      const { fieldMetaResolver = [] } = column;
+      let meta = column.meta || {};
+
+      for (let i = 0; i < fieldMetaResolver.length; i += 1) {
+        const fieldResolver = fieldMetaResolver[i];
+
+        if (typeof fieldResolver === "function") {
+          meta = fieldResolver(colModelCopy, rowData, column.dataIndex) || meta;
+        }
+      }
+
+      return {
+        ...column,
+        meta,
+      };
+    });
+  }
+
   buildFormFieldsModal(fieldName: string, index: number, fields: *) {
     const { columnModel, removeContent } = this.props;
-    const chunkedColumnModel = buildVariableSizeFieldSection(columnModel);
+    const resolvedColumnModel = this.applyFieldResolvers(columnModel, fields.get(index));
+    const chunkedColumnModel = buildVariableSizeFieldSection(resolvedColumnModel);
+
     const fieldToRender = chunkedColumnModel.map((columns) => {
       const mappedFields = columns.map((item) => {
         let field = <div />;
         const label = (item.meta && item.meta.label) || item.name;
         let columnProps = _.cloneDeep(item);
-        const { fieldMetaResolver = [] } = columnProps;
-        const colModelCopy = _.cloneDeep(columnModel);
         let meta = columnProps.meta || {};
         delete columnProps.meta;
-
-        for (let i = 0; i < fieldMetaResolver.length; i += 1) {
-          const fieldResolver = fieldMetaResolver[i];
-
-          if (typeof fieldResolver === "function") {
-            meta = fieldResolver(colModelCopy, fields.get(index), item.dataIndex) || meta;
-          }
-        }
-
         meta = { ...meta, label };
         columnProps = { ...columnProps, props: meta };
 

--- a/src/util.js
+++ b/src/util.js
@@ -35,6 +35,10 @@ export function buildVariableSizeFieldSection(fields) {
   let currentRowWidth = 0;
 
   fields.forEach((field) => {
+    if (field.meta?.hidden) {
+      return;
+    }
+
     const fieldWidth = field.meta && field.meta.width ? field.meta.width : 16;
 
     if (currentRowWidth === 0 || currentRowWidth + fieldWidth > 16) {

--- a/src/util.js
+++ b/src/util.js
@@ -31,10 +31,11 @@ export function chunkConditional(array, size, predicate) {
 }
 
 export function buildVariableSizeFieldSection(fields) {
+  const sortedFields = [...fields].sort();
   const groupedItems = [];
   let currentRowWidth = 0;
 
-  fields.forEach((field) => {
+  sortedFields.forEach((field) => {
     if (field.meta?.hidden) {
       return;
     }

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { sortingFunction as sortColumns } from "./components/columnModel";
 
 // eslint-disable-next-line
 export function chunkConditional(array, size, predicate) {
@@ -31,7 +32,7 @@ export function chunkConditional(array, size, predicate) {
 }
 
 export function buildVariableSizeFieldSection(fields) {
-  const sortedFields = [...fields].sort();
+  const sortedFields = [...fields].sort(sortColumns);
   const groupedItems = [];
   let currentRowWidth = 0;
 


### PR DESCRIPTION
The `FormFieldModal` component did not set proper keys. This caused console warnings as well as erratic runtime behavior. When I fixed that issue, I noticed that the form layout would sometimes get messed up when blurring a lookup field. It appears the form was making room for a hidden field. To resolve that issue, I process field resolvers before form layout, omit hidden fields from the form, and sort the fields to ensure a consistent ordering.