### PR TITLE
#0000 -- include hidden fields into the field group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-datagrid",
-  "version": "0.2.0-alpha.5.0",
+  "version": "0.2.0-alpha.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-datagrid",
-  "version": "0.2.0-alpha.5.0",
+  "version": "0.2.0-alpha.6.0",
   "description": "React data grid component that complies with redux and redux-form. Also exposes a non form version that can be exposed to just render a data grid.",
   "author": "Yadvaindera Sood <ydsood@gmail.com> (https://github.com/ydsood)",
   "license": "ISC",

--- a/src/components/datagridField/util.js
+++ b/src/components/datagridField/util.js
@@ -34,10 +34,12 @@ function chunkConditional(array, predicate) {
 }
 
 function buildVariableSizeFieldSection(columns) {
+  const filteredColumns = columns.filter((column) => !column.meta);
+
   const groupedItems = [];
   let currentRowWidth = 0;
 
-  columns.forEach((column) => {
+  filteredColumns.forEach((column) => {
     const fieldWidth = column.meta.width;
 
     if (column.meta.hidden && groupedItems.length === 0) {

--- a/src/components/datagridField/util.js
+++ b/src/components/datagridField/util.js
@@ -34,15 +34,17 @@ function chunkConditional(array, predicate) {
 }
 
 function buildVariableSizeFieldSection(columns) {
-  const filteredColumns = columns.filter((column) => (!column.meta || !column.meta.hidden));
-
   const groupedItems = [];
   let currentRowWidth = 0;
 
-  filteredColumns.forEach((column) => {
-    const fieldWidth = column.meta.width || 16;
+  columns.forEach((column) => {
+    const fieldWidth = column.meta.width;
 
-    if (column.type === "linebreak") {
+    if (column.meta.hidden && groupedItems.length === 0) {
+      groupedItems.push([column]);
+    } else if (column.meta.hidden) {
+      groupedItems[groupedItems.length - 1].push(column);
+    } else if (column.type === "linebreak") {
       currentRowWidth = Number.MAX_SAFE_INTEGER;
     } else if (currentRowWidth === 0 || currentRowWidth + fieldWidth > 16) {
       currentRowWidth = fieldWidth;
@@ -75,7 +77,7 @@ function createFieldGroups(
           let columnProps = _.cloneDeep(column);
           let meta = columnProps.meta || {};
           delete columnProps.meta;
-          meta = { ...meta, label, "aria-label":ariaLabel };
+          meta = { ...meta, label, "aria-label": ariaLabel };
           columnProps = { ...columnProps, props: meta };
 
           const required = column.meta && column.meta.required;


### PR DESCRIPTION
We will need to include hidden fields into the field group, so we could maintain the correct redux-form state. for example, use a hidden checkbox field to check weather it is a copied data, etc.