### PR TITLE
support remote store, pagination, sort, and export

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,6 @@
   "javascript.validate.enable": false,
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -1,17 +1,15 @@
-//@flow
-import React, { Component } from 'react';
-import Datagrid, { PaginationHandler } from 'redux-form-datagrid';
-import logo from './logo.svg';
-import './App.css';
-import columnModel from './__mocks__/columnDef';
-import data from './__mocks__/columnData';
-import NoDataComponent from './NoDataComponent';
-import CellComponent from './component/CellComponent';
-import BeneForm from './component/BeneForm';
-
+// @flow
+import React, { Component } from "react";
+import Datagrid from "redux-form-datagrid";
+import logo from "./logo.svg";
+import "./App.css";
+import columnModel from "./__mocks__/columnDef";
+import data from "./__mocks__/columnData";
+import NoDataComponent from "./NoDataComponent";
+import CellComponent from "./component/CellComponent";
+import BeneForm from "./component/BeneForm";
 
 type Props = any;
-
 
 class App extends Component<Props> {
   render() {
@@ -23,7 +21,7 @@ class App extends Component<Props> {
         </header>
         <p className="App-intro">
           To get started, edit <code>src/App.js</code> and save to reload.
-         </p>
+        </p>
         <Datagrid columnModel={columnModel} data={data} name="sample" localStore pageSize={5} title="Sample Grid with pagination" />
         <br />
         <br />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-datagrid",
-  "version": "0.2.0-alpha.9.0",
+  "version": "0.2.0-alpha.10.0",
   "description": "React data grid component that complies with redux and redux-form. Also exposes a non form version that can be exposed to just render a data grid.",
   "author": "Yadvaindera Sood <ydsood@gmail.com> (https://github.com/ydsood)",
   "license": "ISC",

--- a/src/components/datagrid/index.js
+++ b/src/components/datagrid/index.js
@@ -1,5 +1,7 @@
 import React, { Component } from "react";
-import { Table, Segment } from "semantic-ui-react";
+import {
+  Table, Segment, Dimmer, Loader,
+} from "semantic-ui-react";
 import buildGrid from "../gridHOC";
 import TableRow from "../tableRow";
 
@@ -28,6 +30,7 @@ type StaticDatagridProps = {
   classes: Object,
   noDataImage: string,
   noDataMessage: string,
+  loading: boolean,
 };
 
 class StaticDatagrid extends Component<StaticDatagridProps> {
@@ -84,6 +87,7 @@ class StaticDatagrid extends Component<StaticDatagridProps> {
       noDataImage,
       noDataMessage,
       noDataComponent: NoDataComponent,
+      loading,
     } = this.props;
 
     let columnSpan = columnModel.get().length;
@@ -102,7 +106,12 @@ class StaticDatagrid extends Component<StaticDatagridProps> {
       </Table.Row>
     );
     const tableBody = !data || data.length === 0 ? emptyBody : this.buildTableRows();
-    return <Table.Body>{tableBody}</Table.Body>;
+    return (
+      <Table.Body>
+        <Dimmer active={loading} inverted><Loader /></Dimmer>
+        {tableBody}
+      </Table.Body>
+    );
   }
 
   render() {

--- a/src/components/gridHOC.jsx
+++ b/src/components/gridHOC.jsx
@@ -9,12 +9,12 @@ import { createUseStyles } from "react-jss";
 import type { StaticDatagrid } from "./datagrid";
 import ColumnModel from "./columnModel";
 import type { ColumnModelType } from "./columnModel";
-import { PaginationControls, PaginationHandler } from "./plugins/pagination";
-import { SortingControlHeader, SortingHandler } from "./plugins/sorting";
+import { PaginationControls, GetPaginationHandler } from "./plugins/pagination";
+import { SortingControlHeader, GetSortingHandler } from "./plugins/sorting";
 import { SearchBar, SearchHandler } from "./plugins/search";
 import { EditControls, EditHandler } from "./plugins/edit";
-import { ExportControls } from "./plugins/export";
-import { LocalStore } from "./store";
+import GetExportControls from "./plugins/export";
+import { LocalStore, RemoteStore } from "./store";
 import type {
   LocalStore as LocalStoreType,
   RemoteStore as RemoteStoreType,
@@ -51,6 +51,9 @@ type Props = {
   basic: string,
   classes: Object,
   hideTableHeader: boolean,
+  mode?: "local" | "remote",
+  fetchData: Function,
+  query: Object,
 };
 
 type StoreType = LocalStoreType | RemoteStoreType;
@@ -61,6 +64,7 @@ type State = {
   sortedData: Array<Object>,
   renderedData: Array<Object>,
   activeColumn: String,
+  loading: boolean,
 };
 
 const includeReduxFormIndex = (arr: Array<Object>) => arr.map((item, index) => ({
@@ -90,26 +94,30 @@ export default (Grid: StaticDatagrid) => {
 
     constructor(props: Props) {
       super(props);
-
+      this.mode = props.mode;
       this.colModel = new ColumnModel(props.columnModel);
-      this.paginationHandler = new PaginationHandler(props.pageSize);
-      this.sortingHandler = new SortingHandler(props.columnModel);
+      this.paginationHandler = GetPaginationHandler(this.mode, props.pageSize);
+      this.sortingHandler = GetSortingHandler(this.mode, props.columnModel);
       this.searchHandler = new SearchHandler(props.searchable, props.columnModel);
       this.editHandler = new EditHandler();
-
       this.buildTitleBar = this.buildTitleBar.bind(this);
       this.buildTableHeaders = this.buildTableHeaders.bind(this);
       this.buildTableFooter = this.buildTableFooter.bind(this);
       this.updateGridState = this.updateGridState.bind(this);
-
-      this.state = {
-        store: new LocalStore(includeReduxFormIndex(this.props.data)),
-        renderedData: includeReduxFormIndex(this.props.data),
-      };
+      if (!this.isLocalMode()) {
+        this.state = {
+          store: new RemoteStore(this.props.fetchData, props.pageSize),
+        };
+      } else {
+        this.state = {
+          store: new LocalStore(includeReduxFormIndex(this.props.data)),
+          renderedData: includeReduxFormIndex(this.props.data),
+        };
+      }
     }
 
     componentDidMount() {
-      this.setState({ store: new LocalStore(includeReduxFormIndex(this.props.data)) });
+      this.updateGridState();
     }
 
     componentDidUpdate(prevProps: Props) {
@@ -132,6 +140,10 @@ export default (Grid: StaticDatagrid) => {
         }
       }
 
+      if (!_.isEqual(prevProps.query, this.props.query)) {
+        this.updateGridState();
+      }
+
       if (!_.isEqual(prevProps.columnModel, this.props.columnModel)) {
         this.colModel = new ColumnModel(this.props.columnModel);
       }
@@ -141,26 +153,43 @@ export default (Grid: StaticDatagrid) => {
       this.state.store.clear();
     }
 
+    isLocalMode() {
+      return this.mode === "local";
+    }
+
     updateGridState() {
-      this.setState((prevState) => ({
-        renderedData: this.paginationHandler.getCurrentPage(
-          this.sortingHandler.sortData(
-            this.searchHandler.filterData(
-              this.editHandler.applySelected(
-                prevState.store.getData(),
+      if (!this.isLocalMode()) {
+        const params = this.paginationHandler.getCurrentPage(
+          this.sortingHandler.sortData(),
+        );
+        this.setState({ loading: true });
+        this.state.store.getData({ ...params, ...this.props.query }).then((response) => {
+          const { data, totalRecords } = response;
+          this.paginationHandler.totalRecords = totalRecords;
+          this.setState({
+            renderedData: includeReduxFormIndex(data),
+            loading: false,
+          });
+        });
+      } else {
+        this.setState((prevState) => ({
+          renderedData: this.paginationHandler.getCurrentPage(
+            this.sortingHandler.sortData(
+              this.searchHandler.filterData(
+                this.editHandler.applySelected(
+                  prevState.store.getData(),
+                ),
               ),
             ),
           ),
-        ),
-      }));
+        }));
+      }
     }
 
     buildTitleBar() {
       const {
         title, searchable, searchPlaceholder, basic,
       } = this.props;
-
-      const data = this.state.store.getData();
 
       return (
         <SemanticGrid columns="equal">
@@ -169,10 +198,16 @@ export default (Grid: StaticDatagrid) => {
               <Header as="h4" floated="left">{`${title}`}</Header>
             </SemanticGrid.Column>
           )}
-          {searchable && (
+          {
+            /*
+              TODO: Merge SearchBar from Portal to here? the current implementation is not
+              working, and UI looks like a mess, and this feature never be used
+            */
+          }
+          {searchable && this.isLocalMode() && (
             <SemanticGrid.Column verticalAlign="middle">
               <SearchBar
-                data={data}
+                data={this.state.store.getData()}
                 placeholder={searchPlaceholder}
                 updateGridState={this.updateGridState}
                 searchHandler={this.searchHandler}
@@ -243,9 +278,8 @@ export default (Grid: StaticDatagrid) => {
         columnModel,
         classes,
         basic,
+        mode,
       } = this.props;
-
-      const data = this.state.store.getData();
 
       let columnSpan = this.colModel.get().length;
       if (editable && editIndividualRows) {
@@ -256,12 +290,12 @@ export default (Grid: StaticDatagrid) => {
       }
 
       const style = basic === "very" ? { background: "#fff" } : {};
-
+      const ExportControls = GetExportControls(mode);
       return (
         <Table.Footer fullWidth>
           <Table.Row>
             <Table.HeaderCell colSpan={columnSpan} style={style}>
-              {editable && (
+              {editable && this.isLocalMode() && (
                 <div className={classes.footerButtons}>
                   <EditControls
                     editIndividualRows={editIndividualRows}
@@ -292,7 +326,8 @@ export default (Grid: StaticDatagrid) => {
               {exportable && (
                 <div className={classes.footerButtons}>
                   <ExportControls
-                    data={data}
+                    store={this.state.store}
+                    query={this.props.query}
                     exportFileName={exportFileName}
                     exportButtonLabel={exportButtonLabel}
                     columnModel={columnModel}
@@ -315,6 +350,7 @@ export default (Grid: StaticDatagrid) => {
       return (
         <Grid
           {...this.props}
+          loading={this.state.loading}
           columnModel={this.colModel}
           buildTitleBar={this.buildTitleBar}
           buildTableHeaders={this.buildTableHeaders}
@@ -329,6 +365,7 @@ export default (Grid: StaticDatagrid) => {
 
   GridHOC.defaultProps = {
     pageSize: 5,
+    mode: "local",
   };
 
   const styles = {

--- a/src/components/gridHOC.jsx
+++ b/src/components/gridHOC.jsx
@@ -160,7 +160,7 @@ export default (Grid: StaticDatagrid) => {
     updateGridState() {
       if (!this.isLocalMode()) {
         const params = this.paginationHandler.getCurrentPage(
-          this.sortingHandler.sortData(),
+          this.sortingHandler.getSortingInfo(),
         );
         this.setState({ loading: true });
         this.state.store.getData({ ...params, ...this.props.query }).then((response) => {

--- a/src/components/plugins/export/ExportControls.jsx
+++ b/src/components/plugins/export/ExportControls.jsx
@@ -1,8 +1,12 @@
 import React, { Component } from "react";
 import { Button } from "semantic-ui-react";
+import exportUtil from "./util";
+import type {
+  LocalStore as LocalStoreType,
+} from "../../store";
 
 type Props = {
-  data?: Array<Object>,
+  store: LocalStoreType,
   columnModel: Array<Object>,
   exportButtonLabel?: string,
   exportFileName?: string,
@@ -12,52 +16,17 @@ class ExportControls extends Component<Props> {
   constructor(props: Props) {
     super(props);
     this.exportData = this.exportData.bind(this);
+    this.data = props.store.getData();
   }
 
   exportData() {
-    const { exportFileName, data, columnModel } = this.props;
-    let CSV = "";
-    let header = "";
-
-    columnModel.forEach((element) => {
-      if (element.export !== false) {
-        header += `${element.name},`;
-      }
-    });
-
-    header = header.slice(0, -1);
-    CSV += `${header}\r\n`;
-
-    for (let i = 0; i < data.length; i += 1) {
-      let rowData = "";
-      for (let j = 0; j < columnModel.length; j += 1) {
-        if (columnModel[j].export !== false) {
-          const value = columnModel[j].getValue
-            ? columnModel[j].getValue(data[i][columnModel[j].dataIndex])
-            : data[i][columnModel[j].dataIndex];
-          rowData += `${value},`;
-        }
-      }
-      rowData.slice(0, rowData.length - 1);
-      CSV += `${rowData}\r\n`;
-    }
-
-    if (CSV === "") {
-      return;
-    }
-    const uri = `data:text/csv;charset=utf-8,${escape(CSV)}`;
-    const link = document.createElement("a");
-    link.href = uri;
-    link.style = "visibility: hidden";
-    link.download = `${exportFileName}.csv`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    const { exportFileName, columnModel } = this.props;
+    exportUtil(exportFileName, this.data, columnModel);
   }
 
   render() {
-    const { exportButtonLabel, data } = this.props;
-    if (data.length) {
+    const { exportButtonLabel } = this.props;
+    if (this.data.length) {
       return (
         <Button.Group basic compact>
           <Button icon="file excel" content={exportButtonLabel} onClick={() => this.exportData()} />
@@ -71,7 +40,6 @@ class ExportControls extends Component<Props> {
 ExportControls.defaultProps = {
   exportButtonLabel: "Export",
   exportFileName: "GridData",
-  data: [],
 };
 
 export default ExportControls;

--- a/src/components/plugins/export/ExportControls.jsx
+++ b/src/components/plugins/export/ExportControls.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useState, useEffect } from "react";
 import { Button } from "semantic-ui-react";
 import exportUtil from "./util";
 import type {
@@ -12,30 +12,33 @@ type Props = {
   exportFileName?: string,
 }
 
-class ExportControls extends Component<Props> {
-  constructor(props: Props) {
-    super(props);
-    this.exportData = this.exportData.bind(this);
-    this.data = props.store.getData();
-  }
+const ExportControls = (props: Props) => {
+  const [data, setData] = useState([]);
+  const {
+    store, columnModel, exportFileName, exportButtonLabel,
+  } = props;
+  useEffect(() => {
+    const gridData = store.getData();
+    setData(gridData);
+  }, []);
 
-  exportData() {
-    const { exportFileName, columnModel } = this.props;
-    exportUtil(exportFileName, this.data, columnModel);
-  }
+  useEffect(() => {
+    const gridData = store.getData();
+    setData(gridData);
+  }, [store]);
 
-  render() {
-    const { exportButtonLabel } = this.props;
-    if (this.data.length) {
-      return (
-        <Button.Group basic compact>
-          <Button icon="file excel" content={exportButtonLabel} onClick={() => this.exportData()} />
-        </Button.Group>
-      );
-    }
-    return "";
+  const exportData = () => {
+    exportUtil(exportFileName, data, columnModel);
+  };
+  if (data?.length) {
+    return (
+      <Button.Group basic compact>
+        <Button icon="file excel" content={exportButtonLabel} onClick={() => exportData()} />
+      </Button.Group>
+    );
   }
-}
+  return "";
+};
 
 ExportControls.defaultProps = {
   exportButtonLabel: "Export",

--- a/src/components/plugins/export/RemoteStoreExportControls.jsx
+++ b/src/components/plugins/export/RemoteStoreExportControls.jsx
@@ -13,7 +13,10 @@ type Props = {
   exportFileName?: string,
 }
 
-const ExportControls = (props: Props) => {
+// Remote Store Export export all data in the grid, not just the rendering page
+// it ignores pagination information, sorting information.
+// only thing takes effect for the data is the filtering query
+const RemoteStoreExportControls = (props: Props) => {
   const {
     exportFileName, columnModel, store, exportButtonLabel, query,
   } = props;
@@ -33,9 +36,9 @@ const ExportControls = (props: Props) => {
   );
 };
 
-ExportControls.defaultProps = {
+RemoteStoreExportControls.defaultProps = {
   exportButtonLabel: "Export",
   exportFileName: "GridData",
 };
 
-export default ExportControls;
+export default RemoteStoreExportControls;

--- a/src/components/plugins/export/RemoteStoreExportControls.jsx
+++ b/src/components/plugins/export/RemoteStoreExportControls.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import { Button } from "semantic-ui-react";
+import exportUtil from "./util";
+import type {
+  RemoteStore as RemoteStoreType,
+} from "../../store";
+
+type Props = {
+  store: RemoteStoreType,
+  query: Object,
+  columnModel: Array<Object>,
+  exportButtonLabel?: string,
+  exportFileName?: string,
+}
+
+const ExportControls = (props: Props) => {
+  const {
+    exportFileName, columnModel, store, exportButtonLabel, query,
+  } = props;
+  const [loading, setIsLoading] = useState(false);
+
+  const exportData = async () => {
+    setIsLoading(true);
+    const { data } = await store.getData({ ...query });
+    setIsLoading(false);
+    exportUtil(exportFileName, data, columnModel);
+  };
+
+  return (
+    <Button.Group basic compact>
+      <Button loading={loading} icon="file excel" content={exportButtonLabel} onClick={exportData} />
+    </Button.Group>
+  );
+};
+
+ExportControls.defaultProps = {
+  exportButtonLabel: "Export",
+  exportFileName: "GridData",
+};
+
+export default ExportControls;

--- a/src/components/plugins/export/index.js
+++ b/src/components/plugins/export/index.js
@@ -1,1 +1,12 @@
-export { default as ExportControls } from "./ExportControls";
+import ExportControls from "./ExportControls";
+import RemoteStoreExportControls from "./RemoteStoreExportControls";
+
+const GetExportControls = (mode: "remote" | "local") => {
+  if (mode === "remote") {
+    return RemoteStoreExportControls;
+  }
+
+  return ExportControls;
+};
+
+export default GetExportControls;

--- a/src/components/plugins/export/util.js
+++ b/src/components/plugins/export/util.js
@@ -1,3 +1,6 @@
+// TODO: this util method is pulled from previous ExportControls component
+// so it can be used for both LocalExportControl and RemoteExportControl
+// looking for some other library to handle export special characters and prevent CSV injection
 const exportData = (exportFileName, data, columnModel) => {
   let CSV = "";
   let header = "";

--- a/src/components/plugins/export/util.js
+++ b/src/components/plugins/export/util.js
@@ -1,0 +1,41 @@
+const exportData = (exportFileName, data, columnModel) => {
+  let CSV = "";
+  let header = "";
+
+  columnModel.forEach((element) => {
+    if (element.export !== false) {
+      header += `${element.name},`;
+    }
+  });
+
+  header = header.slice(0, -1);
+  CSV += `${header}\r\n`;
+
+  for (let i = 0; i < data.length; i += 1) {
+    let rowData = "";
+    for (let j = 0; j < columnModel.length; j += 1) {
+      if (columnModel[j].export !== false) {
+        const value = columnModel[j].getValue
+          ? columnModel[j].getValue(data[i][columnModel[j].dataIndex])
+          : data[i][columnModel[j].dataIndex];
+        rowData += `${value},`;
+      }
+    }
+    rowData.slice(0, rowData.length - 1);
+    CSV += `${rowData}\r\n`;
+  }
+
+  if (CSV === "") {
+    return;
+  }
+  const uri = `data:text/csv;charset=utf-8,${escape(CSV)}`;
+  const link = document.createElement("a");
+  link.href = uri;
+  link.style = "visibility: hidden";
+  link.download = `${exportFileName}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+
+export default exportData;

--- a/src/components/plugins/pagination/PaginationControls.jsx
+++ b/src/components/plugins/pagination/PaginationControls.jsx
@@ -11,7 +11,7 @@ type Props = {
 const PaginationControls = ({
   paginationHandler,
   updateGridState,
-}: Props) => ((paginationHandler.data.length > 0) && (
+}: Props) => ((paginationHandler.getTotalNumberOfRecords() > 0) && (
   <Fragment>
     {!paginationHandler.isOnFirstPage() && (
       <Icon
@@ -46,7 +46,7 @@ const PaginationControls = ({
         {`${paginationHandler.getFirstRecordPosition()} - ${paginationHandler.getLastRecordPosition()}`}
       </span>
       <span> of </span>
-      <span>{paginationHandler.data.length}</span>
+      <span>{paginationHandler.getTotalNumberOfRecords()}</span>
     </span>
     {!paginationHandler.isOnLastPage() && (
       <Icon

--- a/src/components/plugins/pagination/PaginationHandler.js
+++ b/src/components/plugins/pagination/PaginationHandler.js
@@ -25,6 +25,8 @@ export default class PaginationHandler {
 
   getCurrentPage: Function;
 
+  getTotalNumberOfRecords: Function;
+
   constructor(pageSize: number) {
     this.cursor = 0;
     this.data = [];
@@ -40,6 +42,11 @@ export default class PaginationHandler {
     this.isOnFirstPage = this.isOnFirstPage.bind(this);
     this.isOnLastPage = this.isOnLastPage.bind(this);
     this.getCurrentPage = this.getCurrentPage.bind(this);
+    this.getTotalNumberOfRecords = this.getTotalNumberOfRecords.bind(this);
+  }
+
+  getTotalNumberOfRecords() {
+    return this.data.length;
   }
 
   moveToNextPage() {

--- a/src/components/plugins/pagination/RemotePaginationHandler.js
+++ b/src/components/plugins/pagination/RemotePaginationHandler.js
@@ -1,0 +1,114 @@
+// @flow
+
+export default class RemotePaginationHandler {
+  page: Number;
+
+  totalRecords: Number;
+
+  pageSize: Number;
+
+  moveToNextPage: Function;
+
+  moveToPreviousPage: Function;
+
+  moveToFirstPage: Function;
+
+  moveToLastPage: Function;
+
+  getFirstRecordPosition: Function;
+
+  getLastRecordPosition: Function;
+
+  isOnFirstPage: Function;
+
+  isOnLastPage: Function;
+
+  getCurrentPage: Function;
+
+  getTotalNumberOfRecords: Function;
+
+  constructor(pageSize: number, totalRecords: number) {
+    this.page = 0;
+    this.pageSize = pageSize;
+    this.totalRecords = totalRecords;
+    this.moveToNextPage = this.moveToNextPage.bind(this);
+    this.moveToPreviousPage = this.moveToPreviousPage.bind(this);
+    this.moveToFirstPage = this.moveToFirstPage.bind(this);
+    this.moveToLastPage = this.moveToLastPage.bind(this);
+    this.getFirstRecordPosition = this.getFirstRecordPosition.bind(this);
+    this.getLastRecordPosition = this.getLastRecordPosition.bind(this);
+    this.isOnFirstPage = this.isOnFirstPage.bind(this);
+    this.isOnLastPage = this.isOnLastPage.bind(this);
+    this.getCurrentPage = this.getCurrentPage.bind(this);
+    this.getTotalNumberOfRecords = this.getTotalNumberOfRecords.bind(this);
+  }
+
+  getTotalNumberOfRecords() {
+    return this.totalRecords;
+  }
+
+  getTotalPages() {
+    this.totalPages = parseInt(this.totalRecords / this.pageSize, 10)
+      + (this.totalRecords % this.pageSize === 0 ? 0 : 1);
+    return this.totalPages;
+  }
+
+  moveToNextPage() {
+    const { page } = this;
+
+    const nextPage = page + 1;
+    if (nextPage >= 0 && nextPage < this.getTotalPages()) {
+      this.page = nextPage;
+    }
+  }
+
+  moveToPreviousPage() {
+    const { page } = this;
+
+    const previousPage = page - 1;
+    if (previousPage >= 0) {
+      this.page = previousPage;
+    } else if (previousPage < 0) {
+      this.page = 0;
+    }
+  }
+
+  moveToFirstPage() {
+    this.page = 0;
+  }
+
+  moveToLastPage() {
+    return this.getTotalPages() - 1;
+  }
+
+  getFirstRecordPosition(): number {
+    return this.page * this.pageSize + 1;
+  }
+
+  getLastRecordPosition(): number {
+    const currentCursor = (this.page + 1) * this.pageSize;
+
+    if (currentCursor >= this.totalRecords) {
+      return this.totalRecords;
+    }
+
+    return currentCursor;
+  }
+
+  isOnFirstPage(): boolean {
+    return this.page === 0;
+  }
+
+  isOnLastPage(): number {
+    return this.page === this.getTotalPages() - 1;
+  }
+
+  getCurrentPage(params: Object = {}): Object {
+    const { page, pageSize } = this;
+    return {
+      ...params,
+      page,
+      pageSize,
+    };
+  }
+}

--- a/src/components/plugins/pagination/RemotePaginationHandler.js
+++ b/src/components/plugins/pagination/RemotePaginationHandler.js
@@ -28,7 +28,7 @@ export default class RemotePaginationHandler {
   getTotalNumberOfRecords: Function;
 
   constructor(pageSize: number, totalRecords: number) {
-    this.page = 0;
+    this.page = 1;
     this.pageSize = pageSize;
     this.totalRecords = totalRecords;
     this.moveToNextPage = this.moveToNextPage.bind(this);
@@ -57,7 +57,7 @@ export default class RemotePaginationHandler {
     const { page } = this;
 
     const nextPage = page + 1;
-    if (nextPage >= 0 && nextPage < this.getTotalPages()) {
+    if (nextPage > 0 && nextPage <= this.getTotalPages()) {
       this.page = nextPage;
     }
   }
@@ -66,27 +66,27 @@ export default class RemotePaginationHandler {
     const { page } = this;
 
     const previousPage = page - 1;
-    if (previousPage >= 0) {
+    if (previousPage >= 1) {
       this.page = previousPage;
-    } else if (previousPage < 0) {
-      this.page = 0;
+    } else if (previousPage < 1) {
+      this.page = 1;
     }
   }
 
   moveToFirstPage() {
-    this.page = 0;
+    this.page = 1;
   }
 
   moveToLastPage() {
-    return this.getTotalPages() - 1;
+    this.page = this.getTotalPages();
   }
 
   getFirstRecordPosition(): number {
-    return this.page * this.pageSize + 1;
+    return (this.page - 1) * this.pageSize + 1;
   }
 
   getLastRecordPosition(): number {
-    const currentCursor = (this.page + 1) * this.pageSize;
+    const currentCursor = this.page * this.pageSize;
 
     if (currentCursor >= this.totalRecords) {
       return this.totalRecords;
@@ -96,11 +96,11 @@ export default class RemotePaginationHandler {
   }
 
   isOnFirstPage(): boolean {
-    return this.page === 0;
+    return this.page === 1;
   }
 
   isOnLastPage(): number {
-    return this.page === this.getTotalPages() - 1;
+    return this.page === this.getTotalPages();
   }
 
   getCurrentPage(params: Object = {}): Object {

--- a/src/components/plugins/pagination/index.js
+++ b/src/components/plugins/pagination/index.js
@@ -2,8 +2,17 @@
 
 import PaginationControls from "./PaginationControls";
 import PaginationHandler from "./PaginationHandler";
+import RemotePaginationHandler from "./RemotePaginationHandler";
+
+const GetPaginationHandler = (mode: "remote" | "local", pageSize: number) => {
+  if (mode === "remote") {
+    return new RemotePaginationHandler(pageSize);
+  }
+
+  return new PaginationHandler(pageSize);
+};
 
 export {
   PaginationControls,
-  PaginationHandler,
+  GetPaginationHandler,
 };

--- a/src/components/plugins/sorting/RemoteSortingHandler.js
+++ b/src/components/plugins/sorting/RemoteSortingHandler.js
@@ -7,7 +7,7 @@ export default class RemoteSortingHandler {
 
   columnModel: Array<Object>;
 
-  sortData: Function;
+  getSortingInfo: Function;
 
   updateActiveColumn: Function;
 
@@ -17,7 +17,7 @@ export default class RemoteSortingHandler {
 
     this.columnModel = columnModel || [];
 
-    this.sortData = this.sortData.bind(this);
+    this.getSortingInfo = this.getSortingInfo.bind(this);
     this.updateActiveColumn = this.updateActiveColumn.bind(this);
   }
 
@@ -32,7 +32,7 @@ export default class RemoteSortingHandler {
     }
   }
 
-  sortData(): Object {
+  getSortingInfo(): Object {
     const { activeColumn, isAscending } = this;
 
     if (!activeColumn) {

--- a/src/components/plugins/sorting/RemoteSortingHandler.js
+++ b/src/components/plugins/sorting/RemoteSortingHandler.js
@@ -1,0 +1,47 @@
+// @flow
+
+export default class RemoteSortingHandler {
+  activeColumn: String;
+
+  isAscending: Boolean;
+
+  columnModel: Array<Object>;
+
+  sortData: Function;
+
+  updateActiveColumn: Function;
+
+  constructor(columnModel: Array<Object>) {
+    this.activeColumn = "";
+    this.isAscending = false;
+
+    this.columnModel = columnModel || [];
+
+    this.sortData = this.sortData.bind(this);
+    this.updateActiveColumn = this.updateActiveColumn.bind(this);
+  }
+
+  updateActiveColumn(activeColumn: String) {
+    if (activeColumn !== this.activeColumn) {
+      this.activeColumn = activeColumn;
+      this.isAscending = true;
+    } else if (this.isAscending) {
+      this.isAscending = false;
+    } else {
+      this.activeColumn = "";
+    }
+  }
+
+  sortData(): Object {
+    const { activeColumn, isAscending } = this;
+
+    if (!activeColumn) {
+      return {};
+    }
+
+    return {
+      sortColumn: activeColumn,
+      sortDirection: isAscending ? "ASC" : "DESC",
+    };
+  }
+}

--- a/src/components/plugins/sorting/index.js
+++ b/src/components/plugins/sorting/index.js
@@ -1,8 +1,17 @@
 // @flow
 import SortingControlHeader from "./SortingControlHeader";
 import SortingHandler from "./SortingHandler";
+import RemoteSortingHandler from "./RemoteSortingHandler";
+
+const GetSortingHandler = (mode: "remote" | "local", columnModel: Array<Object>) => {
+  if (mode === "remote") {
+    return new RemoteSortingHandler(columnModel);
+  }
+
+  return new SortingHandler(columnModel);
+};
 
 export {
   SortingControlHeader,
-  SortingHandler,
+  GetSortingHandler,
 };

--- a/src/components/store/remoteStore.js
+++ b/src/components/store/remoteStore.js
@@ -5,9 +5,41 @@ class RemoteStore {
 
   getSize: () => number
 
-  constructor(getData: () => Array<Object>, getSize: () => number) {
-    this.getData = getData;
-    this.getSize = getSize;
+  constructor(fetcher: () => Array<Object>, pageSize: number = 10) {
+    this.totalRecords = 0;
+    this.pageSize = pageSize;
+    this.fetcher = fetcher;
+  }
+
+  async getData(params: Object = {}): Promise<Array<Object>> {
+    const fetcherParams = {
+      page: 0,
+      pageSize: this.pageSize,
+      ...params,
+    };
+
+    try {
+      const response = await this.fetcher(fetcherParams);
+      const { data, totalRecords } = response;
+      this.totalRecords = totalRecords;
+
+      return {
+        data,
+        totalRecords,
+      };
+    } catch (error) {
+      throw new Error("Data fetch failed");
+    }
+  }
+
+  getSize(): number {
+    return this.totalRecords;
+  }
+
+  clear() {
+    this.fetcher = null;
+    this.pageSize = 0;
+    this.totalRecords = 0;
   }
 }
 

--- a/src/components/store/remoteStore.js
+++ b/src/components/store/remoteStore.js
@@ -13,8 +13,6 @@ class RemoteStore {
 
   async getData(params: Object = {}): Promise<Array<Object>> {
     const fetcherParams = {
-      page: 0,
-      pageSize: this.pageSize,
       ...params,
     };
 


### PR DESCRIPTION
support remote store, pagination, sort, and export.

there are two things I noticed, looks like we were trying to support search and edit for local store.
and they are not really used and looks mess, so in this PR, I keep those two only for local store, not for remote store.

so far, Im not seeing any use cases of the edit,search feature in portal. Need to take a look if we need to support this two for remote store.