### PR TITLE
Add support for default sorting options in grid components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-datagrid",
-  "version": "0.2.0-alpha.10.1",
+  "version": "0.2.0-alpha.11.0",
   "description": "React data grid component that complies with redux and redux-form. Also exposes a non form version that can be exposed to just render a data grid.",
   "author": "Yadvaindera Sood <ydsood@gmail.com> (https://github.com/ydsood)",
   "license": "ISC",

--- a/src/components/gridHOC.jsx
+++ b/src/components/gridHOC.jsx
@@ -54,6 +54,9 @@ type Props = {
   mode?: "local" | "remote",
   fetchData: Function,
   query: Object,
+  defaultSortColumn?: String,
+  defaultSortDirection?: "ASC" | "DESC",
+  onSortChange?: Function,
 };
 
 type StoreType = LocalStoreType | RemoteStoreType;
@@ -97,7 +100,11 @@ export default (Grid: StaticDatagrid) => {
       this.mode = props.mode;
       this.colModel = new ColumnModel(props.columnModel);
       this.paginationHandler = GetPaginationHandler(this.mode, props.pageSize);
-      this.sortingHandler = GetSortingHandler(this.mode, props.columnModel);
+      this.sortingHandler = GetSortingHandler(this.mode, props.columnModel, {
+        defaultSortColumn: props.defaultSortColumn,
+        defaultSortDirection: props.defaultSortDirection,
+        onSortChange: props.onSortChange,
+      });
       this.searchHandler = new SearchHandler(props.searchable, props.columnModel);
       this.editHandler = new EditHandler();
       this.buildTitleBar = this.buildTitleBar.bind(this);

--- a/src/components/plugins/sorting/RemoteSortingHandler.js
+++ b/src/components/plugins/sorting/RemoteSortingHandler.js
@@ -11,14 +11,30 @@ export default class RemoteSortingHandler {
 
   updateActiveColumn: Function;
 
-  constructor(columnModel: Array<Object>) {
-    this.activeColumn = "";
-    this.isAscending = false;
+  onSortChange: Function | null;
+
+  constructor(columnModel: Array<Object>, options?: Object) {
+    const {
+      defaultSortColumn,
+      defaultSortDirection,
+      onSortChange,
+    } = options || {};
+
+    this.activeColumn = defaultSortColumn || "";
+    // Default to ASC when a default column is provided but no direction
+    this.isAscending = defaultSortColumn ? (defaultSortDirection === "DESC" ? false : true) : false;
 
     this.columnModel = columnModel || [];
 
+    this.onSortChange = typeof onSortChange === "function" ? onSortChange : null;
+
     this.getSortingInfo = this.getSortingInfo.bind(this);
     this.updateActiveColumn = this.updateActiveColumn.bind(this);
+
+    // Emit initial sort state if provided
+    if (this.activeColumn && this.onSortChange) {
+      this.emitSortChange();
+    }
   }
 
   updateActiveColumn(activeColumn: String) {
@@ -30,6 +46,8 @@ export default class RemoteSortingHandler {
     } else {
       this.activeColumn = "";
     }
+
+    this.emitSortChange();
   }
 
   getSortingInfo(): Object {
@@ -43,5 +61,19 @@ export default class RemoteSortingHandler {
       sortColumn: activeColumn,
       sortDirection: isAscending ? "ASC" : "DESC",
     };
+  }
+
+  emitSortChange() {
+    if (!this.onSortChange) return;
+    const info = this.getSortingInfo();
+    if (info && info.sortColumn) {
+      try {
+        // Prefer object payload
+        this.onSortChange(info);
+      } catch (e) {
+        // Fallback to positional args if consumer expects them
+        try { this.onSortChange(info.sortColumn, info.sortDirection); } catch (_) { /* noop */ }
+      }
+    }
   }
 }

--- a/src/components/plugins/sorting/SortingHandler.js
+++ b/src/components/plugins/sorting/SortingHandler.js
@@ -11,14 +11,33 @@ export default class SortingHandler {
 
   updateActiveColumn: Function;
 
-  constructor(columnModel: Array<Object>) {
-    this.activeColumn = "";
-    this.isAscending = false;
+  getSortingInfo: Function;
+
+  onSortChange: Function | null;
+
+  constructor(columnModel: Array<Object>, options?: Object) {
+    const {
+      defaultSortColumn,
+      defaultSortDirection,
+      onSortChange,
+    } = options || {};
+
+    this.activeColumn = defaultSortColumn || "";
+    // Default to ASC when a default column is provided but no direction
+    this.isAscending = defaultSortColumn ? (defaultSortDirection === "DESC" ? false : true) : false;
 
     this.columnModel = columnModel || [];
 
+    this.onSortChange = typeof onSortChange === "function" ? onSortChange : null;
+
     this.sortData = this.sortData.bind(this);
     this.updateActiveColumn = this.updateActiveColumn.bind(this);
+    this.getSortingInfo = this.getSortingInfo.bind(this);
+
+    // Emit initial sort state if provided
+    if (this.activeColumn && this.onSortChange) {
+      this.emitSortChange();
+    }
   }
 
   updateActiveColumn(activeColumn: String) {
@@ -30,6 +49,8 @@ export default class SortingHandler {
     } else {
       this.activeColumn = "";
     }
+
+    this.emitSortChange();
   }
 
   sortData(data: Array<Object>): Array<Object> {
@@ -63,5 +84,32 @@ export default class SortingHandler {
       const descending = second > first ? -1 : 1;
       return !isAscending ? ascending : descending;
     });
+  }
+
+  getSortingInfo(): Object {
+    const { activeColumn, isAscending } = this;
+
+    if (!activeColumn) {
+      return {};
+    }
+
+    return {
+      sortColumn: activeColumn,
+      sortDirection: isAscending ? "ASC" : "DESC",
+    };
+  }
+
+  emitSortChange() {
+    if (!this.onSortChange) return;
+    const info = this.getSortingInfo();
+    if (info && info.sortColumn) {
+      try {
+        // Prefer object payload
+        this.onSortChange(info);
+      } catch (e) {
+        // Fallback to positional args if consumer expects them
+        try { this.onSortChange(info.sortColumn, info.sortDirection); } catch (_) { /* noop */ }
+      }
+    }
   }
 }

--- a/src/components/plugins/sorting/index.js
+++ b/src/components/plugins/sorting/index.js
@@ -3,12 +3,16 @@ import SortingControlHeader from "./SortingControlHeader";
 import SortingHandler from "./SortingHandler";
 import RemoteSortingHandler from "./RemoteSortingHandler";
 
-const GetSortingHandler = (mode: "remote" | "local", columnModel: Array<Object>) => {
+const GetSortingHandler = (
+  mode: "remote" | "local",
+  columnModel: Array<Object>,
+  options?: Object,
+) => {
   if (mode === "remote") {
-    return new RemoteSortingHandler(columnModel);
+    return new RemoteSortingHandler(columnModel, options);
   }
 
-  return new SortingHandler(columnModel);
+  return new SortingHandler(columnModel, options);
 };
 
 export {


### PR DESCRIPTION
**Summarize the new sort state capabilities and how they affect runtime behavior in local and remote modes.**

**Default sort:** Allows initializing the grid’s sort via defaultSortColumn and defaultSortDirection so the first render reflects a chosen sort.
**Change callback:** Invokes onSortChange on every sort update (and once on init if defaults provided) with { sortColumn, sortDirection } to let you persist/restore externally.
**Local mode:** Applies sorting before pagination, keeping the existing data flow unchanged while reflecting the chosen sort state.
**Remote mode:** Includes current sort in fetch params, so your backend receives sortColumn and sortDirection for server-side sorting.
**Optional and safe:** If you don’t provide these props, behavior is unchanged; existing sorting logic and header interactions stay the same.
**UI feedback:** Header sort indicators still show ascending/descending state based on the active column.